### PR TITLE
chore: release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.2.0 (2026-02-11)
+
+### Documentation
+
+- Overhaul README with `claude mcp add` install command and npx-based setup
+- Replace JSON examples with 22 natural language "What You Can Ask" examples (all verified)
+- Compact tool reference table
+- 242 lines → 127 lines
+
 ## v1.1.0 (2026-02-11)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@coo-quack/calc-mcp",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"type": "module",
 	"bin": {
 		"calc-mcp": "dist/index.js"


### PR DESCRIPTION
## v1.2.0

- README overhaul (merged via #1)
- CHANGELOG updated
- Version bump to 1.2.0
- npm published

Approve to merge, then tag will be pushed.