### PR TITLE
docs: add install guides for Claude, VS Code, Cursor, and Windsurf

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Ask in natural language — the AI picks the right tool automatically.
 | `luhn` | Validate / generate check digits |
 | `ip` | IPv4/IPv6 info, CIDR range |
 | `color` | HEX ↔ RGB ↔ HSL |
-| `convert` | Length, weight, temp, area, volume, speed, data |
+| `convert` | 7 categories, 58 units: length (m, km, mi, ft, ...), weight (kg, lb, oz, ...), temperature (°C, °F, K), area (m², ha, acre, tsubo, tatami), volume (l, gal, cup, tbsp, ...), speed (km/h, mph, kn, ...), data (kb, mb, gb, tb, ...) |
 | `char_info` | Unicode code point, block, category |
 | `jwt_decode` | Decode header + payload (no verification) |
 | `url_parse` | Protocol, host, path, params, hash |


### PR DESCRIPTION
## Changes

Expand the Install section with per-tool setup instructions:

- **Claude Code** — `claude mcp add` one-liner
- **Claude Desktop** — config path for macOS/Windows + JSON
- **VS Code (GitHub Copilot)** — `.vscode/mcp.json` (workspace) + `settings.json` (global)
- **Cursor** — `~/.cursor/mcp.json`
- **Windsurf** — `~/.codeium/windsurf/mcp_config.json`

All using `npx -y @coo-quack/calc-mcp` — no local install needed.

Note: This PR is based on the README from #2. Merge #2 first, then this.