### PR TITLE
fix: add repository url for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
 		"@types/bun": "latest",
 		"typescript": "^5.9.3"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/coo-quack/calc-mcp"
+	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.26.0",
 		"date-fns": "^4.1.0",


### PR DESCRIPTION
npm publish with `--provenance` requires `repository.url` in package.json to match the GitHub repo.

Without it, CI publish fails with:
```
Error verifying sigstore provenance bundle: package.json: "repository.url" is "", expected to match "https://github.com/coo-quack/calc-mcp"
```

This fix adds the repository field. Once merged, the v1.4.0 auto-publish should succeed.