### PR TITLE
fix: correct repository.url for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/coo-quack/calc-mcp"
+		"url": "git+https://github.com/coo-quack/calc-mcp.git"
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.26.0",


### PR DESCRIPTION
npm provenance verification requires `git+https://` URL format. The publish CI was failing with:

> package.json: "repository.url" is "", expected to match...

This fixes the URL format so `--provenance` works correctly.