### PR TITLE
chore: release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v1.6.0 (2026-02-12)
+
+### Features
+
+- **Documentation site** — Full VitePress-powered docs at [coo-quack.github.io/calc-mcp](https://coo-quack.github.io/calc-mcp/) with tool reference, examples, install guides, and changelog (#13)
+
+### Documentation
+
+- Added documentation site link to README
+- Added release checklist to CONTRIBUTING.md (#15)
+- Updated npx examples with `--prefix /tmp` for better node_modules compatibility
+- Added common ignore patterns to .gitignore
+
 ## v1.5.0 (2026-02-11)
 
 ### Features

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,19 @@
 
 All notable changes to Calc MCP are documented here.
 
+## v1.6.0 (2026-02-12)
+
+### Features
+
+- **Documentation site** — Full VitePress-powered docs at [coo-quack.github.io/calc-mcp](https://coo-quack.github.io/calc-mcp/) with tool reference, examples, install guides, and changelog (#13)
+
+### Documentation
+
+- Added documentation site link to README
+- Added release checklist to CONTRIBUTING.md (#15)
+- Updated npx examples with `--prefix /tmp` for better node_modules compatibility
+- Added common ignore patterns to .gitignore
+
 ## v1.5.0 (2026-02-11)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@coo-quack/calc-mcp",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"type": "module",
 	"bin": {
 		"calc-mcp": "dist/index.js"


### PR DESCRIPTION
## v1.6.0

### Features
- **Documentation site** — Full VitePress-powered docs at [coo-quack.github.io/calc-mcp](https://coo-quack.github.io/calc-mcp/) with tool reference, examples, install guides, and changelog (#13)

### Documentation
- Added documentation site link to README
- Added release checklist to CONTRIBUTING.md (#15)
- Updated npx examples with `--prefix /tmp` for better node_modules compatibility
- Added common ignore patterns to .gitignore

### Checklist
- [x] CHANGELOG.md updated
- [x] docs/changelog.md updated
- [x] All tests pass (194 tests, 280 assertions)
- [x] Lint passes