### PR TITLE
fix: replace Bun.CryptoHasher with node:crypto for Node.js compatibility

### DIFF
--- a/src/tools/hash.ts
+++ b/src/tools/hash.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { z } from "zod";
 import type { ToolDefinition } from "../index.js";
 
@@ -32,9 +33,7 @@ export function execute(input: Input): string {
 	if (input.algorithm === "crc32") {
 		return crc32(input.input);
 	}
-	const hasher = new Bun.CryptoHasher(input.algorithm);
-	hasher.update(input.input);
-	return hasher.digest("hex");
+	return createHash(input.algorithm).update(input.input).digest("hex");
 }
 
 export const tool: ToolDefinition = {


### PR DESCRIPTION
## Summary
- Replace `Bun.CryptoHasher` with `node:crypto` `createHash` in `src/tools/hash.ts`
- Fixes `Bun is not defined` error when running via `npx` (Node.js runtime)
- `node:crypto` works in both Bun and Node.js

## Context
When users run calc-mcp via `npx` (which uses Node.js), the hash tool fails because `Bun.CryptoHasher` is a Bun-specific API. The standard `node:crypto` module provides the same functionality and is compatible with both runtimes.

## Test plan
- [x] All 194 existing tests pass
- [ ] Run `npx --prefix /tmp -y @coo-quack/calc-mcp` and verify hash tool works