### PR TITLE
fix(regex): auto-add g flag for matchAll action

### DIFF
--- a/src/tools/regex.ts
+++ b/src/tools/regex.ts
@@ -33,6 +33,9 @@ export function execute(input: Input): string {
 	if (input.action === "replace" && !flags.includes("g")) {
 		flags = `g${flags}`;
 	}
+	if (input.action === "matchAll" && !flags.includes("g")) {
+		flags = `g${flags}`;
+	}
 	const regex = new RegExp(input.pattern, flags);
 
 	switch (input.action) {
@@ -52,9 +55,6 @@ export function execute(input: Input): string {
 			});
 		}
 		case "matchAll": {
-			if (!input.flags?.includes("g")) {
-				throw new Error("matchAll requires the 'g' flag");
-			}
 			const matches = withTimeout(() => [...input.text.matchAll(regex)]);
 			return JSON.stringify(
 				matches.map((m) => ({

--- a/tests/tools/regex.test.ts
+++ b/tests/tools/regex.test.ts
@@ -47,10 +47,13 @@ describe("regex", () => {
 		expect(result).toBe("hello earth");
 	});
 
-	test("matchAll requires g flag", () => {
-		expect(() =>
-			execute({ pattern: "\\d+", text: "abc", action: "matchAll" }),
-		).toThrow("matchAll requires the 'g' flag");
+	test("matchAll adds g flag automatically", () => {
+		const result = JSON.parse(
+			execute({ pattern: "\\d+", text: "a1b2c3", action: "matchAll" }),
+		);
+		expect(result).toHaveLength(3);
+		expect(result[0].match).toBe("1");
+		expect(result[2].match).toBe("3");
 	});
 
 	test("works with flags", () => {


### PR DESCRIPTION
## Summary
- `matchAll` action now automatically adds the `g` flag when not provided, consistent with `match` and `replace` actions
- Previously `matchAll` threw an error requiring explicit `g` flag, while `match` and `replace` auto-added it
- Updated tests to verify the new auto-add behavior

## Test plan
- [x] Existing unit tests pass (`bun test tests/tools/regex.test.ts`)
- [ ] Verify `matchAll` works without explicit `g` flag via MCP call
- [ ] Verify `matchAll` still works correctly with explicit `g` flag