### PR TITLE
Release v1.7.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 All notable changes to Calc MCP are documented here.
 
+## v1.7.1 (2026-02-12)
+
+### Bug Fixes
+
+- **regex** — Auto-add `g` flag for `matchAll` action, consistent with `match` and `replace` (#25)
+
 ## v1.7.0 (2026-02-12)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@coo-quack/calc-mcp",
-	"version": "1.7.0",
+	"version": "1.7.1",
 	"type": "module",
 	"bin": {
 		"calc-mcp": "dist/index.js"


### PR DESCRIPTION
## v1.7.1

### Bug Fixes

- **regex** — Auto-add `g` flag for `matchAll` action, consistent with `match` and `replace` (#25)
- **ci** — Check remote tags via `git ls-remote` instead of local `git rev-parse` to avoid duplicate tag push failure

## Checklist

- [x] CHANGELOG.md updated
- [x] Version bumped to 1.7.1
- [x] Tag v1.7.1 created
- [x] All tests passing (359 tests)