### PR TITLE
fix(ci): check remote tags to avoid duplicate push failure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           VERSION="v${{ needs.check.outputs.version }}"
-          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+          if git ls-remote --tags origin "$VERSION" | grep -q "$VERSION"; then
             echo "Tag $VERSION already exists, skipping"
           else
             git tag "$VERSION"


### PR DESCRIPTION
## Summary

- Replace `git rev-parse` with `git ls-remote --tags origin` in publish workflow
- `actions/checkout@v4` does not fetch tags by default, so `git rev-parse` always misses existing remote tags, causing duplicate tag push failures

## Test plan

- [ ] Merge and verify the publish workflow succeeds when a tag already exists on remote