### PR TITLE
chore: release v1.7.2

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,13 @@
 
 All notable changes to Calc MCP are documented here.
 
+## v1.7.2 (2026-02-13)
+
+### Bug Fixes
+
+- **cron_parse** — Now respects the `timezone` parameter (was previously ignored; all calculations used local time)
+- **count** — Improve Shift_JIS byte calculation accuracy (handle ¥, ‾, and supplementary plane characters correctly)
+
 ## v1.7.1 (2026-02-12)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@coo-quack/calc-mcp",
-	"version": "1.7.1",
+	"version": "1.7.2",
 	"type": "module",
 	"bin": {
 		"calc-mcp": "dist/index.js"


### PR DESCRIPTION
## v1.7.2 (2026-02-13)

### Bug Fixes

- **cron_parse** — Now respects the `timezone` parameter (was previously ignored; all calculations used local time) (#28)
- **count** — Improve Shift_JIS byte calculation accuracy (handle ¥, ‾, and supplementary plane characters correctly) (#30)

### Changes

**cron_parse timezone support:**
- Add timezone validation with clear error messages
- Optimize formatToParts lookup (Map reuse)
- Normalize hour=24 → hour=0 for midnight edge case
- Compute day-of-week from UTC date

**count Shift_JIS improvements:**
- Accurate handling for ¥ (U+00A5) and ‾ (U+203E) as 1 byte
- Treat supplementary plane characters as 1-byte replacement
- Document known limitation: BMP non-representables counted as 2 bytes

### Testing

All 233 tests pass across 21 tools.

---

Ready to merge and publish.