### PR TITLE
chore: add CLAUDE.md with project rules and release workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,8 +114,6 @@ Registration: import in `src/index.ts` → add to `tools` array.
 
 ### Release PR Process
 
-Reference: v1.7.2 / PR #31
-
 1. **Branch**: Create `release/vX.Y.Z` from `main`
 2. **Version bump**: Update `version` in `package.json`
 3. **Changelog**: Update `docs/changelog.md`


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with project rules for Claude Code
  - Git/GitHub rules: prohibit co-author trailers and AI attribution
  - Release workflow: changelog policy, release PR process (based on v1.7.2)
  - Tech stack reference (Bun, Biome, commands)