### PR TITLE
ci: dispatch marketplace sync on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,15 @@ jobs:
               --notes-file /tmp/release-notes.md
           fi
 
+      - name: Sync marketplace
+        env:
+          GH_TOKEN: ${{ secrets.MARKETPLACE_TOKEN }}
+        run: |
+          gh api repos/coo-quack/claude-code-marketplace/dispatches \
+            -f event_type=plugin-released \
+            -f 'client_payload[plugin]=calc-mcp' \
+            -f 'client_payload[version]=${{ needs.check.outputs.version }}'
+
       - name: Install mcp-publisher
         run: |
           curl -sL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \


### PR DESCRIPTION
Adds a "Sync marketplace" step to `release.yml`, dispatching a `plugin-released` event to `coo-quack/claude-code-marketplace` after a release — the same mechanism sensitive-canary and do-not-compact already use.

## Background

calc-mcp v2.0.2 was released on 2026-06-27 but the marketplace was never updated, because this repo's release workflow lacked the dispatch step. The missed sync is covered manually by coo-quack/claude-code-marketplace#20.

## Note

Requires `MARKETPLACE_TOKEN` to be available to this repo. It is already used by sensitive-canary's and do-not-compact's release workflows — if it is an org-level secret, confirm this repo is in its visibility scope; otherwise add it as a repo secret.