### PR TITLE
chore: add CODEOWNERS requiring admin review for .github changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# CI/CD, workflows, and repo automation require code owner (admin) approval
+/.github/ @chata @chataclaw


### PR DESCRIPTION
Adds `.github/CODEOWNERS` assigning `.github/` (workflows, CI/CD, automation config, and CODEOWNERS itself) to the admin accounts. Combined with the "require code owner review" branch rules, PRs touching CI cannot merge without explicit admin approval.