### PR TITLE
chore: set dependency minimumReleaseAge to 1 day

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,3 @@
+[install]
+# Supply-chain policy: reject packages published less than 1 day ago (seconds)
+minimumReleaseAge = 86400

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:recommended"],
   "dependencyDashboard": true,
   "osvVulnerabilityAlerts": true,
-  "minimumReleaseAge": "7 days",
+  "minimumReleaseAge": "1 day",
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true
@@ -14,7 +14,7 @@
       "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
       "automerge": true,
       "automergeType": "pr",
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "1 day"
     },
     {
       "description": "Update package managers",


### PR DESCRIPTION
Aligns the minimum release age across Renovate and the package manager at 1 day:

- `renovate.json`: `minimumReleaseAge` 7 days → 1 day (global and automerge rule)
- `bunfig.toml`: `install.minimumReleaseAge = 86400` (seconds)

One day is enough to block the typical compromised-package window (malicious versions are usually yanked within hours) while keeping security patches flowing quickly.