### PR TITLE
ci: auto-merge dependabot PRs when checks pass

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,19 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions: {}
+
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]' && github.repository_owner == 'coo-quack'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Enables GitHub native auto-merge on Dependabot PRs. The merge happens only after all required status checks pass (including the package manager's 1-day minimumReleaseAge gate), and required reviews still apply — a Dependabot PR touching `.github/` would still wait for code owner approval.

Note: if checks fail because a dependency is younger than the 1-day release-age policy, auto-merge stays pending; re-run CI after the package ages to let it merge.