### PR TITLE
feat: add Claude Code plugin manifest and MCP server definition

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "calc-mcp",
+  "description": "21 MCP tools for math, randomness, dates, encoding, hashing, and more — deterministic and accurate.",
+  "version": "2.0.2",
+  "author": {
+    "name": "coo-quack"
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,12 @@
   "mcpServers": {
     "calc-mcp": {
       "command": "npx",
-      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@2.0.2"]
+      "args": [
+        "--prefix",
+        "${CLAUDE_PLUGIN_ROOT}/.npx-prefix",
+        "-y",
+        "@coo-quack/calc-mcp@2.0.2"
+      ]
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "calc-mcp": {
+      "command": "npx",
+      "args": ["-y", "@coo-quack/calc-mcp@latest"]
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "calc-mcp": {
       "command": "npx",
-      "args": ["-y", "@coo-quack/calc-mcp@latest"]
+      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@2.0.2"]
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,8 +111,8 @@ Registration: import in `src/index.ts` → add to `tools` array.
 
 ### Release PR Process
 
-1. **Branch**: Create `release/vX.Y.Z` from `main`
-2. **Version bump**: Update `version` in `package.json`
+1. **Branch**: Create `release/vX.Y.Z` from `develop`
+2. **Version bump**: Update `version` in `package.json`, the pinned version in `.claude-plugin/plugin.json` and `.mcp.json`, and the pinned `@coo-quack/calc-mcp@X.Y.Z` references in `README.md`, `docs/install.md`, `docs/getting-started.md`, and `docs/troubleshooting.md` (`tests/version-sync.test.ts` enforces this)
 3. **Changelog**: Update `CHANGELOG.md`
    - Add a new `## vX.Y.Z (YYYY-MM-DD)` section at the top (below the heading)
    - Categorize entries: Features, Bug Fixes, Improvements, Security, Tests, Documentation, etc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ When bumping a version, open a PR from `develop` → `main` with:
    - `docs/changelog.md` is a symlink to `CHANGELOG.md` — do not edit it separately
    - This content is automatically used as the GitHub Release notes by `release.yml`
 3. Update the pinned version in `.claude-plugin/plugin.json` and `.mcp.json`
-4. Update the pinned `@coo-quack/calc-mcp@X.Y.Z` references in `docs/install.md`, `docs/getting-started.md`, and `docs/troubleshooting.md`
+4. Update the pinned `@coo-quack/calc-mcp@X.Y.Z` references in `README.md`, `docs/install.md`, `docs/getting-started.md`, and `docs/troubleshooting.md`
 5. Review `docs/tools.md` — add/update any changed tool parameters or examples
 6. Review `docs/examples.md` — add examples for new features
 7. Review `README.md` — update tool table and examples if needed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,9 +66,11 @@ When bumping a version, open a PR from `develop` → `main` with:
 2. Update `CHANGELOG.md` with a new `## vX.Y.Z (YYYY-MM-DD)` section
    - `docs/changelog.md` is a symlink to `CHANGELOG.md` — do not edit it separately
    - This content is automatically used as the GitHub Release notes by `release.yml`
-3. Review `docs/tools.md` — add/update any changed tool parameters or examples
-4. Review `docs/examples.md` — add examples for new features
-5. Review `README.md` — update tool table and examples if needed
+3. Update the pinned version in `.claude-plugin/plugin.json` and `.mcp.json`
+4. Update the pinned `@coo-quack/calc-mcp@X.Y.Z` references in `docs/install.md`, `docs/getting-started.md`, and `docs/troubleshooting.md`
+5. Review `docs/tools.md` — add/update any changed tool parameters or examples
+6. Review `docs/examples.md` — add examples for new features
+7. Review `README.md` — update tool table and examples if needed
 
 After merging into `main`, `release.yml` automatically:
 - Publishes to npm with provenance

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.2
 
 > Works with Claude Desktop, VS Code Copilot, Cursor, Windsurf, and any MCP client — [setup guides below](#install).
 
+> **Windows note**: These examples use `/tmp` as the npx prefix — on Windows, replace it with a writable directory such as `C:\Temp`.
+
 ---
 
 ## Why?
@@ -140,11 +142,24 @@ Ask in natural language — your AI assistant selects the appropriate tool.
 
 ## Install
 
+> **Windows note**: The examples below use `/tmp` as the npx prefix. On Windows, replace it with a writable directory such as `C:\Temp`.
+
 ### Claude Code
 
 ```bash
 claude mcp add -s user calc-mcp -- npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.2
 ```
+
+### Claude Code plugin
+
+Also available as a plugin from the [coo-quack marketplace](https://github.com/coo-quack/claude-code-marketplace):
+
+```
+/plugin marketplace add coo-quack/claude-code-marketplace
+/plugin install calc-mcp@coo-quack
+```
+
+See the [installation guide](https://coo-quack.github.io/calc-mcp/install) for details.
 
 ### Claude Desktop / Cursor / Windsurf
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ LLMs hallucinate calculations, can't generate true random numbers, and struggle 
 
 ```bash
 # Claude Code
-claude mcp add -s user calc-mcp -- npx --prefix /tmp -y @coo-quack/calc-mcp@latest
+claude mcp add -s user calc-mcp -- npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.2
 
 # Or just run it
-npx --prefix /tmp -y @coo-quack/calc-mcp@latest
+npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.2
 ```
 
 > Works with Claude Desktop, VS Code Copilot, Cursor, Windsurf, and any MCP client — [setup guides below](#install).
@@ -143,7 +143,7 @@ Ask in natural language — your AI assistant selects the appropriate tool.
 ### Claude Code
 
 ```bash
-claude mcp add -s user calc-mcp -- npx --prefix /tmp -y @coo-quack/calc-mcp@latest
+claude mcp add -s user calc-mcp -- npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.2
 ```
 
 ### Claude Desktop / Cursor / Windsurf
@@ -162,7 +162,7 @@ Add to your config file:
   "mcpServers": {
     "calc-mcp": {
       "command": "npx",
-      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@latest"]
+      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@2.0.2"]
     }
   }
 }
@@ -177,7 +177,7 @@ Add to `.vscode/mcp.json` in your workspace:
   "servers": {
     "calc-mcp": {
       "command": "npx",
-      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@latest"]
+      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@2.0.2"]
     }
   }
 }
@@ -213,7 +213,7 @@ Available tags:
 Calc MCP works with any MCP-compatible client. Run the server via stdio:
 
 ```bash
-npx --prefix /tmp -y @coo-quack/calc-mcp@latest
+npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.2
 ```
 
 Point your client's MCP config to the command above. The server communicates over **stdio** using the standard [Model Context Protocol](https://modelcontextprotocol.io/).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,6 +10,8 @@ The fastest way to add Calc MCP is via Claude Code:
 claude mcp add -s user calc-mcp -- npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.2
 ```
 
+> **Windows note**: This example uses `/tmp` as the npx prefix. On Windows, replace it with a writable directory such as `C:\Temp`.
+
 For other clients (Claude Desktop, VS Code, Cursor, Windsurf, Docker), see the [Installation](/install) page.
 
 ## Your First Tool Call

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@ Get Calc MCP running in under 2 minutes.
 The fastest way to add Calc MCP is via Claude Code:
 
 ```bash
-claude mcp add -s user calc-mcp -- npx --prefix /tmp -y @coo-quack/calc-mcp@latest
+claude mcp add -s user calc-mcp -- npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.2
 ```
 
 For other clients (Claude Desktop, VS Code, Cursor, Windsurf, Docker), see the [Installation](/install) page.

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,6 +2,8 @@
 
 Calc MCP works with any MCP-compatible client. Below are setup guides for popular AI assistants.
 
+> **Windows note**: The examples below use `/tmp` as the npx prefix. On Windows, replace it with a writable directory such as `C:\Temp`.
+
 ## Claude Code
 
 The fastest way to add Calc MCP to Claude Code:

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,7 +7,7 @@ Calc MCP works with any MCP-compatible client. Below are setup guides for popula
 The fastest way to add Calc MCP to Claude Code:
 
 ```bash
-claude mcp add -s user calc-mcp -- npx --prefix /tmp -y @coo-quack/calc-mcp@latest
+claude mcp add -s user calc-mcp -- npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.2
 ```
 
 This adds the server to your user-level MCP configuration.
@@ -19,6 +19,17 @@ claude mcp list
 ```
 
 You should see `calc-mcp` in the list.
+
+## Claude Code plugin
+
+Calc MCP is also available as a Claude Code plugin from the [coo-quack marketplace](https://github.com/coo-quack/claude-code-marketplace):
+
+```
+/plugin marketplace add coo-quack/claude-code-marketplace
+/plugin install calc-mcp@coo-quack
+```
+
+The plugin launches the pinned release version of `@coo-quack/calc-mcp` defined in `.mcp.json`. After installing, restart Claude Code and confirm `calc-mcp` appears in `/mcp`.
 
 ## Claude Desktop
 
@@ -40,7 +51,7 @@ Add to your Claude Desktop config file:
   "mcpServers": {
     "calc-mcp": {
       "command": "npx",
-      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@latest"]
+      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@2.0.2"]
     }
   }
 }
@@ -57,7 +68,7 @@ Add to `~/.cursor/mcp.json`:
   "mcpServers": {
     "calc-mcp": {
       "command": "npx",
-      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@latest"]
+      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@2.0.2"]
     }
   }
 }
@@ -74,7 +85,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
   "mcpServers": {
     "calc-mcp": {
       "command": "npx",
-      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@latest"]
+      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@2.0.2"]
     }
   }
 }
@@ -91,7 +102,7 @@ For workspace-specific setup, add `.vscode/mcp.json` in your project:
   "servers": {
     "calc-mcp": {
       "command": "npx",
-      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@latest"]
+      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@2.0.2"]
     }
   }
 }
@@ -129,7 +140,7 @@ Available tags:
 Calc MCP works with any MCP-compatible client that supports stdio transport. To integrate with a client not listed above, configure it to run:
 
 ```bash
-npx --prefix /tmp -y @coo-quack/calc-mcp@latest
+npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.2
 ```
 
 The server communicates over **stdio** using the standard [Model Context Protocol](https://modelcontextprotocol.io/). Most clients accept a `command` + `args` configuration similar to the examples above.
@@ -139,13 +150,13 @@ The server communicates over **stdio** using the standard [Model Context Protoco
 You can also run the server directly for testing:
 
 ```bash
-npx --prefix /tmp -y @coo-quack/calc-mcp@latest
+npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.2
 ```
 
 Or install globally:
 
 ```bash
-npm install -g @coo-quack/calc-mcp@latest
+npm install -g @coo-quack/calc-mcp@2.0.2
 calc-mcp
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -37,7 +37,7 @@ npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.2
 To check the latest published version:
 
 ```bash
-npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.2 --version
+npx --prefix /tmp -y @coo-quack/calc-mcp@latest --version
 ```
 
 ## Still stuck?

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,7 +29,7 @@ sh: calc-mcp: command not found
 This happens because npx resolves the scoped package locally but fails to link the binary correctly. All the examples on this page already include the fix (`--prefix /tmp`), which forces npx to use a separate directory for package resolution:
 
 ```bash
-npx --prefix /tmp -y @coo-quack/calc-mcp@latest
+npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.2
 ```
 
 ## Version info
@@ -37,7 +37,7 @@ npx --prefix /tmp -y @coo-quack/calc-mcp@latest
 To check the latest published version:
 
 ```bash
-npx --prefix /tmp -y @coo-quack/calc-mcp@latest --version
+npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.2 --version
 ```
 
 ## Still stuck?

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,7 +26,7 @@ If you run `npx` inside a directory that contains `node_modules`, npx may fail w
 sh: calc-mcp: command not found
 ```
 
-This happens because npx resolves the scoped package locally but fails to link the binary correctly. All the examples on this page already include the fix (`--prefix /tmp`), which forces npx to use a separate directory for package resolution:
+This happens because npx resolves the scoped package locally but fails to link the binary correctly. All the npx examples on this page already include the fix (`--prefix /tmp`), which forces npx to use a separate directory for package resolution:
 
 ```bash
 npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.2
@@ -37,7 +37,7 @@ npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.2
 To check the latest published version:
 
 ```bash
-npx --prefix /tmp -y @coo-quack/calc-mcp@latest --version
+npm view @coo-quack/calc-mcp version
 ```
 
 ## Still stuck?

--- a/tests/version-sync.test.ts
+++ b/tests/version-sync.test.ts
@@ -1,18 +1,20 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
-const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+const root = join(import.meta.dir, "..");
+const read = (path: string) => readFileSync(join(root, path), "utf8");
+
+const pkg = JSON.parse(read("package.json"));
 
 describe("version pin consistency", () => {
   test(".claude-plugin/plugin.json matches package.json version", () => {
-    const plugin = JSON.parse(
-      readFileSync(".claude-plugin/plugin.json", "utf8"),
-    );
+    const plugin = JSON.parse(read(".claude-plugin/plugin.json"));
     expect(plugin.version).toBe(pkg.version);
   });
 
   test(".mcp.json pins the current package version", () => {
-    const mcp = JSON.parse(readFileSync(".mcp.json", "utf8"));
+    const mcp = JSON.parse(read(".mcp.json"));
     const args = mcp.mcpServers["calc-mcp"].args;
     expect(args).toContain(`@coo-quack/calc-mcp@${pkg.version}`);
   });
@@ -25,8 +27,9 @@ describe("version pin consistency", () => {
       "docs/troubleshooting.md",
     ];
     for (const file of files) {
-      const content = readFileSync(file, "utf8");
+      const content = read(file);
       const pins = content.match(/@coo-quack\/calc-mcp@\d+\.\d+\.\d+/g) ?? [];
+      expect(pins.length).toBeGreaterThan(0);
       for (const pin of pins) {
         expect(pin).toBe(`@coo-quack/calc-mcp@${pkg.version}`);
       }

--- a/tests/version-sync.test.ts
+++ b/tests/version-sync.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+
+describe("version pin consistency", () => {
+  test(".claude-plugin/plugin.json matches package.json version", () => {
+    const plugin = JSON.parse(
+      readFileSync(".claude-plugin/plugin.json", "utf8"),
+    );
+    expect(plugin.version).toBe(pkg.version);
+  });
+
+  test(".mcp.json pins the current package version", () => {
+    const mcp = JSON.parse(readFileSync(".mcp.json", "utf8"));
+    const args = mcp.mcpServers["calc-mcp"].args;
+    expect(args).toContain(`@coo-quack/calc-mcp@${pkg.version}`);
+  });
+
+  test("docs and README pin the current package version", () => {
+    const files = [
+      "README.md",
+      "docs/install.md",
+      "docs/getting-started.md",
+      "docs/troubleshooting.md",
+    ];
+    for (const file of files) {
+      const content = readFileSync(file, "utf8");
+      const pins = content.match(/@coo-quack\/calc-mcp@\d+\.\d+\.\d+/g) ?? [];
+      for (const pin of pins) {
+        expect(pin).toBe(`@coo-quack/calc-mcp@${pkg.version}`);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Installing calc-mcp as a Claude Code plugin from the coo-quack marketplace succeeded but registered no MCP server. This was because the repository had neither `.claude-plugin/plugin.json` nor `.mcp.json`, which are required for Claude Code to recognize and launch the plugin.

## Solution

Added both required manifest files:

- `.claude-plugin/plugin.json` — Claude Code plugin metadata (name, version, description, author)
- `.mcp.json` — MCP server definition pointing to the published npm package via npx

The plugin now properly exposes the calc-mcp MCP server when installed.

## Verification

To verify this works:

1. Reinstall the plugin in Claude Code from the coo-quack marketplace
2. Run `/mcp` in Claude Code
3. Confirm that `calc-mcp` appears in the list of available MCP servers