### PR TITLE
ci: mint app token for marketplace sync instead of MARKETPLACE_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,9 +109,18 @@ jobs:
               --notes-file /tmp/release-notes.md
           fi
 
+      - name: Mint app token for marketplace sync
+        id: marketplace-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.BACKPORT_APP_ID }}
+          private-key: ${{ secrets.BACKPORT_APP_PRIVATE_KEY }}
+          owner: coo-quack
+          repositories: claude-code-marketplace
+
       - name: Sync marketplace
         env:
-          GH_TOKEN: ${{ secrets.MARKETPLACE_TOKEN }}
+          GH_TOKEN: ${{ steps.marketplace-token.outputs.token }}
         run: |
           gh api repos/coo-quack/claude-code-marketplace/dispatches \
             -f event_type=plugin-released \


### PR DESCRIPTION
## Problem

The v2.0.3 release run failed at the "Sync marketplace" step because `GH_TOKEN` was empty. The workflow referenced a `MARKETPLACE_TOKEN` secret that was never configured, so the GitHub API dispatch call to the marketplace repo exited with code 4 (unauthenticated).

## Solution

Replace the unconfigured `MARKETPLACE_TOKEN` secret with an app token minted from the org's GitHub App (`BACKPORT_APP_ID` / `BACKPORT_APP_PRIVATE_KEY`), scoped to the `claude-code-marketplace` repo. This follows the same pattern already used in `backport.yml`.

The app token:
- Has narrowly scoped permissions (limited to the marketplace repo)
- Is minted fresh for each release
- Uses credentials already configured org-wide for the backport automation

## Release Notes

The manual marketplace sync for v2.0.3 was completed via `gh api` dispatch before this fix was applied (see workflow run 30037126983). The marketplace repo now has the v2.0.3 entry on a feature branch (`chore/sync-calc-mcp-v2.0.3-30037126983`), though the auto-merge PR failed due to that repo's branch protection rules.

The MCP Registry publish step for 2.0.3 was also skipped by the release workflow failure and will catch up on the next release (when this fix is in place).