### PR TITLE
chore: release v2.0.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "calc-mcp",
   "description": "21 MCP tools for math, randomness, dates, encoding, hashing, and more — deterministic and accurate.",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "author": {
     "name": "coo-quack"
   }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,9 +109,18 @@ jobs:
               --notes-file /tmp/release-notes.md
           fi
 
+      - name: Mint app token for marketplace sync
+        id: marketplace-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.BACKPORT_APP_ID }}
+          private-key: ${{ secrets.BACKPORT_APP_PRIVATE_KEY }}
+          owner: coo-quack
+          repositories: claude-code-marketplace
+
       - name: Sync marketplace
         env:
-          GH_TOKEN: ${{ secrets.MARKETPLACE_TOKEN }}
+          GH_TOKEN: ${{ steps.marketplace-token.outputs.token }}
         run: |
           gh api repos/coo-quack/claude-code-marketplace/dispatches \
             -f event_type=plugin-released \

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,7 @@
         "--prefix",
         "${CLAUDE_PLUGIN_ROOT}/.npx-prefix",
         "-y",
-        "@coo-quack/calc-mcp@2.0.3"
+        "@coo-quack/calc-mcp@2.0.4"
       ]
     }
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Calc MCP are documented here.
 
+## v2.0.4 (2026-07-24)
+
+### Improvements
+
+- CI: mint a GitHub App installation token for the marketplace sync dispatch instead of the unconfigured `MARKETPLACE_TOKEN` secret (#154)
+- CI: update `actions/setup-node` to v7 (#145)
+
 ## v2.0.3 (2026-07-24)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ LLMs hallucinate calculations, can't generate true random numbers, and struggle 
 
 ```bash
 # Claude Code
-claude mcp add -s user calc-mcp -- npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.3
+claude mcp add -s user calc-mcp -- npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.4
 
 # Or just run it
-npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.3
+npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.4
 ```
 
 > Works with Claude Desktop, VS Code Copilot, Cursor, Windsurf, and any MCP client — [setup guides below](#install).
@@ -147,7 +147,7 @@ Ask in natural language — your AI assistant selects the appropriate tool.
 ### Claude Code
 
 ```bash
-claude mcp add -s user calc-mcp -- npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.3
+claude mcp add -s user calc-mcp -- npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.4
 ```
 
 ### Claude Code plugin
@@ -177,7 +177,7 @@ Add to your config file:
   "mcpServers": {
     "calc-mcp": {
       "command": "npx",
-      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@2.0.3"]
+      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@2.0.4"]
     }
   }
 }
@@ -192,7 +192,7 @@ Add to `.vscode/mcp.json` in your workspace:
   "servers": {
     "calc-mcp": {
       "command": "npx",
-      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@2.0.3"]
+      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@2.0.4"]
     }
   }
 }
@@ -228,7 +228,7 @@ Available tags:
 Calc MCP works with any MCP-compatible client. Run the server via stdio:
 
 ```bash
-npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.3
+npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.4
 ```
 
 Point your client's MCP config to the command above. The server communicates over **stdio** using the standard [Model Context Protocol](https://modelcontextprotocol.io/).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@ Get Calc MCP running in under 2 minutes.
 The fastest way to add Calc MCP is via Claude Code:
 
 ```bash
-claude mcp add -s user calc-mcp -- npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.3
+claude mcp add -s user calc-mcp -- npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.4
 ```
 
 > **Windows note**: This example uses `/tmp` as the npx prefix. On Windows, replace it with a writable directory such as `C:\Temp`.

--- a/docs/install.md
+++ b/docs/install.md
@@ -9,7 +9,7 @@ Calc MCP works with any MCP-compatible client. Below are setup guides for popula
 The fastest way to add Calc MCP to Claude Code:
 
 ```bash
-claude mcp add -s user calc-mcp -- npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.3
+claude mcp add -s user calc-mcp -- npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.4
 ```
 
 This adds the server to your user-level MCP configuration.
@@ -53,7 +53,7 @@ Add to your Claude Desktop config file:
   "mcpServers": {
     "calc-mcp": {
       "command": "npx",
-      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@2.0.3"]
+      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@2.0.4"]
     }
   }
 }
@@ -70,7 +70,7 @@ Add to `~/.cursor/mcp.json`:
   "mcpServers": {
     "calc-mcp": {
       "command": "npx",
-      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@2.0.3"]
+      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@2.0.4"]
     }
   }
 }
@@ -87,7 +87,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
   "mcpServers": {
     "calc-mcp": {
       "command": "npx",
-      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@2.0.3"]
+      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@2.0.4"]
     }
   }
 }
@@ -104,7 +104,7 @@ For workspace-specific setup, add `.vscode/mcp.json` in your project:
   "servers": {
     "calc-mcp": {
       "command": "npx",
-      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@2.0.3"]
+      "args": ["--prefix", "/tmp", "-y", "@coo-quack/calc-mcp@2.0.4"]
     }
   }
 }
@@ -142,7 +142,7 @@ Available tags:
 Calc MCP works with any MCP-compatible client that supports stdio transport. To integrate with a client not listed above, configure it to run:
 
 ```bash
-npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.3
+npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.4
 ```
 
 The server communicates over **stdio** using the standard [Model Context Protocol](https://modelcontextprotocol.io/). Most clients accept a `command` + `args` configuration similar to the examples above.
@@ -152,13 +152,13 @@ The server communicates over **stdio** using the standard [Model Context Protoco
 You can also run the server directly for testing:
 
 ```bash
-npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.3
+npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.4
 ```
 
 Or install globally:
 
 ```bash
-npm install -g @coo-quack/calc-mcp@2.0.3
+npm install -g @coo-quack/calc-mcp@2.0.4
 calc-mcp
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,7 +29,7 @@ sh: calc-mcp: command not found
 This happens because npx resolves the scoped package locally but fails to link the binary correctly. All the npx examples on this page already include the fix (`--prefix /tmp`), which forces npx to use a separate directory for package resolution:
 
 ```bash
-npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.3
+npx --prefix /tmp -y @coo-quack/calc-mcp@2.0.4
 ```
 
 ## Version info

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coo-quack/calc-mcp",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "mcpName": "io.github.coo-quack/calc-mcp",
   "description": "21 MCP tools for math, randomness, dates, encoding, hashing, and more — deterministic and accurate.",
   "type": "module",


### PR DESCRIPTION
## 概要

v2.0.4 を main へリリースする PR。

## 含まれる変更

- marketplace 同期の認証を、未設定の `MARKETPLACE_TOKEN` secret から実行時に発行する GitHub App installation token へ変更（ https://github.com/coo-quack/calc-mcp/pull/154 ）
- `actions/setup-node` を v7 へ更新（ https://github.com/coo-quack/calc-mcp/pull/145 ）
- バージョンを 2.0.4 へ bump（package.json / plugin.json / .mcp.json / docs / CHANGELOG）

## 背景

Release ワークフローの Sync marketplace ステップが認証エラーで失敗（ https://github.com/coo-quack/calc-mcp/actions/runs/30036738092 ）。npm publish とタグ作成まで完了済みのため、v2.0.3 のままでは check ジョブが release をスキップする状態。patch bump によりリリース一連（npm / Docker / タグ / GitHub Release / marketplace sync / MCP Registry）を再実行し、修正後の挙動を検証する目的。