### PR TITLE
build: pin the base images and pull them from elsewhere

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,16 @@
 # Calc MCP Dockerfile
-FROM oven/bun:1 AS builder
+#
+# Both base images are pinned by digest and pulled from somewhere other than
+# Docker Hub, which rate limits unauthenticated pulls per IP — and GitHub's
+# runners share those. The digests are the multi-arch indexes, since the
+# release builds linux/amd64 and linux/arm64.
+#
+# bun is not a Docker Official Image, so AWS does not mirror it and there is no
+# `ghcr.io/oven-sh/bun`. Google's mirror is a pull-through cache rather than an
+# independent copy: a cache hit never touches Docker Hub, a miss still does.
+# Partial, but better than pulling from Docker Hub every time. Same image
+# either way — verified that this digest resolves identically on both.
+FROM mirror.gcr.io/oven/bun:1@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS builder
 
 WORKDIR /app
 
@@ -15,8 +26,12 @@ COPY . .
 # Build
 RUN bun run build
 
-# Production image
-FROM node:24-alpine
+# Production image.
+#
+# node *is* a Docker Official Image, so this comes from AWS's mirror of those —
+# an independent copy, not a cache of Docker Hub. Verified that the digest
+# resolves identically on `docker.io`, `public.ecr.aws` and `mirror.gcr.io`.
+FROM public.ecr.aws/docker/library/node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
 
 WORKDIR /app
 


### PR DESCRIPTION
Both base images were floating tags pulled from Docker Hub:

```dockerfile
FROM oven/bun:1 AS builder
FROM node:24-alpine
```

Docker Hub rate limits unauthenticated pulls per IP, and GitHub's runners share those — one bad neighbour away from a red build for reasons unrelated to the change under review. It cost `openclaw-cursor-cli` a run today, on `dial tcp ...:443: i/o timeout` resolving a manifest, so this is not hypothetical.

## The change

Same images, pinned by digest, from a different host. Digests are the multi-arch indexes, since the release builds `linux/amd64,linux/arm64`.

| | from | digest resolves identically on |
|---|---|---|
| `node:24-alpine` | `public.ecr.aws/docker/library/node` | `docker.io`, `public.ecr.aws`, `mirror.gcr.io` |
| `oven/bun:1` | `mirror.gcr.io/oven/bun` | `docker.io`, `mirror.gcr.io` |

Verified with `docker buildx imagetools inspect` against each.

**node is a Docker Official Image**, so AWS mirrors it — an independent copy, not a cache.

**bun is not.** AWS only mirrors the official images, and `ghcr.io/oven-sh/bun` does not exist (401). Google's mirror is a *pull-through cache* rather than an independent copy: a cache hit never touches Docker Hub, a miss still does. Partial rather than complete, and the Dockerfile says so rather than implying the dependency is gone.

## Renovate

Both answer anonymous tag listings, so digest updates keep flowing. Checked the cached bun list is current, not a stale snapshot:

```
numeric tags: 1.3.13, 1.3.14, 1.3.2, 1.3.3, ...
```

## Verification

Built locally from the new references:

- image builds
- `node -v` → `v24.18.0`
- runs as `node`, `dist/index.js` present

`docker-test.yml` builds the same Dockerfile on every PR, so CI covers the rest.