### PR TITLE
chore: extend the shared Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,30 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "dependencyDashboard": true,
-  "osvVulnerabilityAlerts": true,
-  "minimumReleaseAge": "1 day",
-  "lockFileMaintenance": {
-    "enabled": true,
-    "automerge": true
-  },
-  "packageRules": [
-    {
-      "description": "Automerge all updates when CI passes",
-      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
-      "automerge": true,
-      "automergeType": "pr",
-      "minimumReleaseAge": "1 day"
-    },
-    {
-      "description": "Update package managers",
-      "matchPackagePatterns": ["npm", "pnpm", "bun"],
-      "enabled": true
-    },
-    {
-      "description": "Group all devDependencies",
-      "matchDepTypes": ["devDependencies"],
-      "groupName": "devDependencies"
-    }
-  ]
+  "extends": ["github>coo-quack/renovate-config"]
 }


### PR DESCRIPTION
40-odd lines → 4. This configuration was a copy of the same block carried by five other repositories, and the copies had drifted. The common part now lives once, in [coo-quack/renovate-config](https://github.com/coo-quack/renovate-config).

```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["github>coo-quack/renovate-config"]
}
```

Two things arrive by inheritance, which this repo did not have before:

- **`helpers:pinGitHubActionDigests`** — action refs get pinned to commit digests and kept current, so a moved tag cannot change what CI runs.
- **The deprecated `matchPackagePatterns` key is gone**, so `renovate-config-validator` stops reporting `Config migration necessary`.

Everything else is unchanged: automerge on green with a one-day minimum release age, the Dependency Dashboard, OSV alerts, lock file maintenance, and devDependencies grouped.

Validated with `renovate-config-validator`, on this file and on the preset.