### PR TITLE
release: promote develop to main

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           # Disable cached GITHUB_TOKEN so we can push with the App token below.
@@ -36,7 +36,7 @@ jobs:
       - name: Mint app token
         if: steps.check.outputs.needed == 'true'
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.BACKPORT_APP_ID }}
           private-key: ${{ secrets.BACKPORT_APP_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - run: bun install
       - run: bun run lint
 
@@ -25,8 +25,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - run: bun install
       - run: bun test tests/tools/
 
@@ -35,11 +35,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - run: bun install
       - run: bun run build
       - run: node --test tests/e2e/mcp-server.test.mjs

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -13,13 +13,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Build Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           push: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,12 +22,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
         run: bun install
@@ -36,7 +36,7 @@ jobs:
         run: bun run docs:build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: docs/.vitepress/dist
 
@@ -52,4 +52,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       should_release: ${{ steps.check.outputs.should_release }}
       version: ${{ steps.check.outputs.version }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - id: check
         run: |
           VERSION=$(node -p "require('./package.json').version")
@@ -37,9 +37,9 @@ jobs:
       id-token: write
       packages: write
     steps:
-      - uses: actions/checkout@v7
-      - uses: oven-sh/setup-bun@v2
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -48,17 +48,17 @@ jobs:
       - run: bun run ci
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           push: true
@@ -111,7 +111,7 @@ jobs:
 
       - name: Mint app token for marketplace sync
         id: marketplace-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.BACKPORT_APP_ID }}
           private-key: ${{ secrets.BACKPORT_APP_PRIVATE_KEY }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN bun run build
 # node *is* a Docker Official Image, so this comes from AWS's mirror of those —
 # an independent copy, not a cache of Docker Hub. Verified that the digest
 # resolves identically on `docker.io`, `public.ecr.aws` and `mirror.gcr.io`.
-FROM public.ecr.aws/docker/library/node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
+FROM public.ecr.aws/docker/library/node:24.18.0-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,16 @@
 # Calc MCP Dockerfile
-FROM oven/bun:1 AS builder
+#
+# Both base images are pinned by digest and pulled from somewhere other than
+# Docker Hub, which rate limits unauthenticated pulls per IP — and GitHub's
+# runners share those. The digests are the multi-arch indexes, since the
+# release builds linux/amd64 and linux/arm64.
+#
+# bun is not a Docker Official Image, so AWS does not mirror it and there is no
+# `ghcr.io/oven-sh/bun`. Google's mirror is a pull-through cache rather than an
+# independent copy: a cache hit never touches Docker Hub, a miss still does.
+# Partial, but better than pulling from Docker Hub every time. Same image
+# either way — verified that this digest resolves identically on both.
+FROM mirror.gcr.io/oven/bun:1@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS builder
 
 WORKDIR /app
 
@@ -15,8 +26,12 @@ COPY . .
 # Build
 RUN bun run build
 
-# Production image
-FROM node:24-alpine
+# Production image.
+#
+# node *is* a Docker Official Image, so this comes from AWS's mirror of those —
+# an independent copy, not a cache of Docker Hub. Verified that the digest
+# resolves identically on `docker.io`, `public.ecr.aws` and `mirror.gcr.io`.
+FROM public.ecr.aws/docker/library/node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
 
 WORKDIR /app
 

--- a/bun.lock
+++ b/bun.lock
@@ -12,9 +12,9 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.3.14",
+        "@biomejs/biome": "2.5.5",
         "@types/bun": "latest",
-        "typescript": "^7.0.0",
+        "typescript": "7.0.2",
         "vitepress": "2.0.0-alpha.18",
       },
     },

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "docs:preview": "vitepress preview docs"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.3.14",
+    "@biomejs/biome": "2.5.5",
     "@types/bun": "latest",
-    "typescript": "^7.0.0",
+    "typescript": "7.0.2",
     "vitepress": "2.0.0-alpha.18"
   },
   "homepage": "https://coo-quack.github.io/calc-mcp/",

--- a/renovate.json
+++ b/renovate.json
@@ -1,30 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "dependencyDashboard": true,
-  "osvVulnerabilityAlerts": true,
-  "minimumReleaseAge": "1 day",
-  "lockFileMaintenance": {
-    "enabled": true,
-    "automerge": true
-  },
-  "packageRules": [
-    {
-      "description": "Automerge all updates when CI passes",
-      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
-      "automerge": true,
-      "automergeType": "pr",
-      "minimumReleaseAge": "1 day"
-    },
-    {
-      "description": "Update package managers",
-      "matchPackagePatterns": ["npm", "pnpm", "bun"],
-      "enabled": true
-    },
-    {
-      "description": "Group all devDependencies",
-      "matchDepTypes": ["devDependencies"],
-      "groupName": "devDependencies"
-    }
-  ]
+  "extends": ["github>coo-quack/renovate-config"]
 }


### PR DESCRIPTION
Six commits, none of which change what gets published.

## Why no version bump

`files` is `["dist/index.js", "README.md", "LICENSE"]`. `src/` is untouched, so `dist/index.js` builds identically.

The `Dockerfile` did change (#157), but only in where the base images come from: both are now pinned by digest and pulled from a mirror rather than Docker Hub, which rate limits unauthenticated pulls per IP and shares those limits across GitHub's runners. The digests resolve to the same images, so `ghcr.io/coo-quack/calc-mcp` would be byte-identical.

`bun` is worth a note: it is not a Docker Official Image, so AWS does not mirror it and there is no `ghcr.io/oven-sh/bun`. Google's `mirror.gcr.io` is a pull-through cache rather than an independent copy — a hit never touches Docker Hub, a miss still does. Partial, and better than pulling from Docker Hub every time.

`package.json` stays at 2.0.4. `release.yml` checks for an existing tag and an existing npm version first, so it skips.

## Also here

Action digests pinned, the shared Renovate preset adopted, the Node base image pinned.

Separately, `claude-code-marketplace` now advertises 2.0.4 — its version-sync workflow had been failing since 2026-07-23 and left the marketplace on 2.0.2.