### PR TITLE
ci: fail on a high advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,24 @@ concurrency:
 permissions: {}
 
 jobs:
+  # GitHub auto-dismissed a CVSS 7.5 advisory in a sibling repo, so its alert
+  # list read as clean while the advisory was live in the tree. The audit
+  # reported it throughout. This is the check that notices.
+  #
+  # The threshold is `high`: below that, an upstream package with no fix
+  # available would hold the branch red for something not worth blocking on.
+  # To accept a specific high knowingly, add `--ignore <GHSA-id>` with a
+  # comment saying why — visible and reviewable, unlike a silent dismissal.
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      - run: bun install
+      - run: bun audit --audit-level=high
+
   lint:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
GitHub auto-dismissed **GHSA-mh99-v99m-4gvg** (CVSS 7.5) in `talkative-lobster`. That repository's alert list read as zero open while the advisory was live in its tree; the audit reported it throughout. It surfaced only because someone ran it by hand.

The same blind spot applies here. `bun audit` has the same `--audit-level` flag, so this is the same check the three pnpm repos are getting.

## Threshold

`high`. One moderate sits in this tree today with no fix available; blocking merges on it would mean blocking on upstream's release schedule.

To accept a specific high knowingly:

```
- run: bun audit --audit-level=high --ignore GHSA-xxxx-xxxx-xxxx  # why
```

Visible in the diff, unlike a dismissal that happens elsewhere.

## State today

`bun audit --audit-level=high` exits 0. Green from the first run.