### PR TITLE
chore: release v2.0.6

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "calc-mcp",
   "description": "21 MCP tools for math, randomness, dates, encoding, hashing, and more — deterministic and accurate.",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "author": {
     "name": "coo-quack"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Calc MCP are documented here.
 
+## v2.0.6 (2026-08-18)
+
+### Maintenance
+
+- Update Node.js to 24.19.0 in CI and the published Docker image (#176, #173, #184)
+- Update devDependencies: @biomejs/biome 2.5.8 (#177, #181), vitepress 2.0.0-alpha.19 (#175), docker/login-action v4.6.0 (#172)
+- Lock file maintenance (#174, #178, #182)
+
 ## v2.0.5 (2026-08-11)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coo-quack/calc-mcp",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "mcpName": "io.github.coo-quack/calc-mcp",
   "description": "21 MCP tools for math, randomness, dates, encoding, hashing, and more — deterministic and accurate.",
   "type": "module",


### PR DESCRIPTION
Maintenance-only release: Node.js 24.19.0, devDependency updates, lock file maintenance. Promotes to main after merge to cut v2.0.6.