### PR TITLE
release: promote develop to main

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "calc-mcp": {
       "command": "npx",
-      "args": ["-y", "@coo-quack/calc-mcp@2.0.5"]
+      "args": ["-y", "@coo-quack/calc-mcp@2.0.6"]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ LLMs hallucinate calculations, can't generate true random numbers, and struggle 
 
 ```bash
 # Claude Code
-claude mcp add -s user calc-mcp -- npx -y @coo-quack/calc-mcp@2.0.5
+claude mcp add -s user calc-mcp -- npx -y @coo-quack/calc-mcp@2.0.6
 
 # Or just run it
-npx -y @coo-quack/calc-mcp@2.0.5
+npx -y @coo-quack/calc-mcp@2.0.6
 ```
 
 > Works with Claude Desktop, VS Code Copilot, Cursor, Windsurf, and any MCP client — [setup guides below](#install).
@@ -143,7 +143,7 @@ Ask in natural language — your AI assistant selects the appropriate tool.
 ### Claude Code
 
 ```bash
-claude mcp add -s user calc-mcp -- npx -y @coo-quack/calc-mcp@2.0.5
+claude mcp add -s user calc-mcp -- npx -y @coo-quack/calc-mcp@2.0.6
 ```
 
 ### Claude Code plugin
@@ -173,7 +173,7 @@ Add to your config file:
   "mcpServers": {
     "calc-mcp": {
       "command": "npx",
-      "args": ["-y", "@coo-quack/calc-mcp@2.0.5"]
+      "args": ["-y", "@coo-quack/calc-mcp@2.0.6"]
     }
   }
 }
@@ -188,7 +188,7 @@ Add to `.vscode/mcp.json` in your workspace:
   "servers": {
     "calc-mcp": {
       "command": "npx",
-      "args": ["-y", "@coo-quack/calc-mcp@2.0.5"]
+      "args": ["-y", "@coo-quack/calc-mcp@2.0.6"]
     }
   }
 }
@@ -224,7 +224,7 @@ Available tags:
 Calc MCP works with any MCP-compatible client. Run the server via stdio:
 
 ```bash
-npx -y @coo-quack/calc-mcp@2.0.5
+npx -y @coo-quack/calc-mcp@2.0.6
 ```
 
 Point your client's MCP config to the command above. The server communicates over **stdio** using the standard [Model Context Protocol](https://modelcontextprotocol.io/).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@ Get Calc MCP running in under 2 minutes.
 The fastest way to add Calc MCP is via Claude Code:
 
 ```bash
-claude mcp add -s user calc-mcp -- npx -y @coo-quack/calc-mcp@2.0.5
+claude mcp add -s user calc-mcp -- npx -y @coo-quack/calc-mcp@2.0.6
 ```
 
 For other clients (Claude Desktop, VS Code, Cursor, Windsurf, Docker), see the [Installation](/install) page.

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,7 +7,7 @@ Calc MCP works with any MCP-compatible client. Below are setup guides for popula
 The fastest way to add Calc MCP to Claude Code:
 
 ```bash
-claude mcp add -s user calc-mcp -- npx -y @coo-quack/calc-mcp@2.0.5
+claude mcp add -s user calc-mcp -- npx -y @coo-quack/calc-mcp@2.0.6
 ```
 
 This adds the server to your user-level MCP configuration.
@@ -51,7 +51,7 @@ Add to your Claude Desktop config file:
   "mcpServers": {
     "calc-mcp": {
       "command": "npx",
-      "args": ["-y", "@coo-quack/calc-mcp@2.0.5"]
+      "args": ["-y", "@coo-quack/calc-mcp@2.0.6"]
     }
   }
 }
@@ -68,7 +68,7 @@ Add to `~/.cursor/mcp.json`:
   "mcpServers": {
     "calc-mcp": {
       "command": "npx",
-      "args": ["-y", "@coo-quack/calc-mcp@2.0.5"]
+      "args": ["-y", "@coo-quack/calc-mcp@2.0.6"]
     }
   }
 }
@@ -85,7 +85,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
   "mcpServers": {
     "calc-mcp": {
       "command": "npx",
-      "args": ["-y", "@coo-quack/calc-mcp@2.0.5"]
+      "args": ["-y", "@coo-quack/calc-mcp@2.0.6"]
     }
   }
 }
@@ -102,7 +102,7 @@ For workspace-specific setup, add `.vscode/mcp.json` in your project:
   "servers": {
     "calc-mcp": {
       "command": "npx",
-      "args": ["-y", "@coo-quack/calc-mcp@2.0.5"]
+      "args": ["-y", "@coo-quack/calc-mcp@2.0.6"]
     }
   }
 }
@@ -140,7 +140,7 @@ Available tags:
 Calc MCP works with any MCP-compatible client that supports stdio transport. To integrate with a client not listed above, configure it to run:
 
 ```bash
-npx -y @coo-quack/calc-mcp@2.0.5
+npx -y @coo-quack/calc-mcp@2.0.6
 ```
 
 The server communicates over **stdio** using the standard [Model Context Protocol](https://modelcontextprotocol.io/). Most clients accept a `command` + `args` configuration similar to the examples above.
@@ -150,13 +150,13 @@ The server communicates over **stdio** using the standard [Model Context Protoco
 You can also run the server directly for testing:
 
 ```bash
-npx -y @coo-quack/calc-mcp@2.0.5
+npx -y @coo-quack/calc-mcp@2.0.6
 ```
 
 Or install globally:
 
 ```bash
-npm install -g @coo-quack/calc-mcp@2.0.5
+npm install -g @coo-quack/calc-mcp@2.0.6
 calc-mcp
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -35,7 +35,7 @@ bun run build
 Or run the command from any directory outside the repository:
 
 ```bash
-npx -y @coo-quack/calc-mcp@2.0.5
+npx -y @coo-quack/calc-mcp@2.0.6
 ```
 
 Anywhere else this is not an issue. Projects that contain `node_modules`, and projects that depend on `@coo-quack/calc-mcp`, both run the published binary correctly.


### PR DESCRIPTION
Re-promotes with the completed v2.0.6 pins (see #188). The previous promotion's Release run failed the version-sync test; this picks up the fix.