### PR TITLE
fix: four tool correctness defects in datetime, ip, url_parse and semver

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ MCP (Model Context Protocol) server providing 21 tools for calculations and oper
 
 - Runtime: Bun
 - Language: TypeScript (strict mode)
-- Linter/Formatter: Biome (tab indentation)
+- Linter/Formatter: Biome (2-space indentation)
 - Docs: VitePress (`docs/`)
 - Dependencies: `@modelcontextprotocol/sdk`, `zod`, `mathjs`, `date-fns`
 
@@ -85,8 +85,10 @@ Registration: import in `src/index.ts` → add to `tools` array.
 
 ## Code Style
 
-- Indentation: tabs (enforced by Biome)
-- Follow Biome rules (`bun run lint`); all warnings are treated as errors in CI
+- Indentation: 2 spaces (enforced by Biome)
+- Follow Biome rules (`bun run lint`) — `biome check .` fails on errors and on
+  formatting differences, but exits 0 on lint warnings, so a growing warning count
+  has to be watched by hand rather than left to CI
 
 ## Git / GitHub Rules
 
@@ -97,7 +99,7 @@ Registration: import in `src/index.ts` → add to `tools` array.
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `ci.yml` | push to main / PR to main | lint + unit test + e2e test |
+| `ci.yml` | PR to main or develop | audit + lint + unit test + e2e test |
 | `release.yml` | push to main | npm publish (only if version is new) + git tag + GitHub Release + MCP Registry |
 | `docs.yml` | push to main / manual | Build & deploy VitePress docs to GitHub Pages |
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -135,10 +135,13 @@ What's the current UNIX timestamp?
 
 ```
 Convert 2026-02-14 12:00 from New York time to Tokyo time
-→ 2026-02-15T02:00:00+09:00 (datetime)
+→ 2026-02-15T02:00:00.000+09:00 (datetime)
 
-Format 2026-02-14 in Tokyo timezone as "yyyy/MM/dd HH:mm"
-→ 2026/02/14 12:00 (datetime)
+Convert 2026-06-15 14:30 from New York time to UTC
+→ 2026-06-15T18:30:00.000+00:00 (datetime, EDT that day)
+
+Format 2026-02-14T09:00:00+09:00 as "yyyy/MM/dd HH:mm" in Tokyo
+→ 2026/02/14 09:00 (datetime)
 ```
 
 ### Date Arithmetic
@@ -380,6 +383,9 @@ Is 192.168.1.50 in 192.168.1.0/24?
 
 Parse IPv6 address 2001:db8::1
 → { ip: "2001:db8::1", version: 6, type: "global" } (ip)
+
+Info on 10.0.0.0/29
+→ { network: "10.0.0.0", broadcast: "10.0.0.7", hostCount: 6, totalAddresses: 8 } (ip)
 ```
 
 ### Colors
@@ -468,6 +474,9 @@ Parse https://example.com/search?q=hello&lang=en
 
 Extract query params from https://api.github.com/search?q=mcp&sort=stars
 → { q: "mcp", sort: "stars" } (url_parse)
+
+Parse https://example.com/s?tag=api&tag=mcp
+→ { tag: ["api", "mcp"] } (url_parse, a repeated key keeps every value)
 ```
 
 ### Unicode Info

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -136,9 +136,9 @@ Get current time, convert timezones, format datetime, or work with UNIX timestam
 
 **Parameters:**
 - `action` (enum) — `now`, `convert`, `format`, or `timestamp`
-- `timezone` (string, optional) — IANA timezone (e.g., `Asia/Tokyo`, `America/New_York`)
-- `datetime` (string, optional) — ISO8601 datetime string for convert/format
-- `fromTimezone` (string, optional) — Source timezone for conversion
+- `timezone` (string, optional) — IANA timezone (e.g., `Asia/Tokyo`, `America/New_York`). Names the output zone for `now`/`format`/`timestamp`; for `convert` it is read as the source zone when `fromTimezone` is absent
+- `datetime` (string, optional) — Datetime string for convert/format/timestamp. A string carrying a UTC designator or a numeric offset (`2026-11-03T14:30:00Z`, `...+09:00`) is absolute, and `fromTimezone` is ignored. A bare wall-clock string (`2026-11-03 14:30`) is read in `fromTimezone`
+- `fromTimezone` (string, optional) — IANA timezone the datetime string is written in, used when the string carries no offset of its own. Defaults to UTC, never the host's local timezone, so results do not depend on the machine the server runs on
 - `toTimezone` (string, optional) — Target timezone for conversion
 - `format` (string, optional) — Output format: `iso`, `date`, `time`, `full`, `short`, date-fns pattern (e.g. `yyyy/MM/dd HH:mm`), or Intl JSON options
 - `timestamp` (number, optional) — UNIX timestamp in seconds for timestamp action
@@ -150,6 +150,12 @@ What time is it in New York?
 
 Convert 1609459200 to ISO8601
 → 2021-01-01T00:00:00Z
+
+2026-11-03 14:30 in New York, in UTC?
+→ 2026-11-03T19:30:00.000+00:00   (EST that day, so UTC-5)
+
+2026-06-15 14:30 in New York, in UTC?
+→ 2026-06-15T18:30:00.000+00:00   (EDT that day, so UTC-4)
 ```
 
 ### date
@@ -390,17 +396,22 @@ IPv4/IPv6 address information, CIDR range calculations, and membership checks.
 
 **Parameters:**
 - `action` (enum) — `info`, `contains`, or `range`
-- `ip` (string, optional) — IP address
-- `cidr` (string, optional) — CIDR notation (e.g., `192.168.1.0/24`)
+- `ip` (string, optional) — IP address. For `info`, IPv4 CIDR notation is also accepted
+- `cidr` (string, optional) — CIDR notation (e.g., `192.168.1.0/24`). For `info`, supplying an IPv4 prefix adds the network details to the result. An IPv6 prefix is rejected with a message naming the address to pass instead
 - `target` (string, optional) — Target IP to check against CIDR
+
+`range` reports both `hostCount`, which excludes the network and broadcast addresses, and `totalAddresses`, which counts every address in the block.
 
 **Examples:**
 ```
 IP range of 192.168.1.0/24?
-→ 192.168.1.1 – .254 (254 hosts)
+→ 192.168.1.1 – .254 (254 hosts, 256 addresses)
 
 Is 192.168.1.50 in 192.168.1.0/24?
 → true
+
+Info on 10.0.0.0/29?
+→ network 10.0.0.0, broadcast 10.0.0.7, hostCount 6, totalAddresses 8
 ```
 
 ### color
@@ -446,10 +457,15 @@ Parse URLs into components.
 **Parameters:**
 - `url` (string) — URL to parse
 
+A query string may repeat a key, which an object cannot represent with one value per key. A key that appears once maps to a string; a key that repeats maps to an array of every value, in the order they appear. The raw `search` string is returned alongside.
+
 **Examples:**
 ```
 Parse https://example.com/search?q=hello
 → host: example.com, pathname: /search, q: "hello"
+
+Parse https://example.com/s?tag=api&tag=mcp
+→ tag: ["api", "mcp"]
 ```
 
 ---

--- a/src/tools/datetime.ts
+++ b/src/tools/datetime.ts
@@ -17,17 +17,23 @@ const schema = {
     .string()
     .max(MAX_TIMEZONE_LENGTH)
     .optional()
-    .describe("IANA timezone (e.g. Asia/Tokyo, America/New_York)"),
+    .describe(
+      "IANA timezone (e.g. Asia/Tokyo, America/New_York). Names the output zone for now/format/timestamp; for convert it is read as the source zone when fromTimezone is absent",
+    ),
   datetime: z
     .string()
     .max(MAX_DATETIME_LENGTH)
     .optional()
-    .describe("ISO8601 datetime string for convert/format"),
+    .describe(
+      "Datetime string for convert/format/timestamp. If it carries a UTC designator or a numeric offset (2026-11-03T14:30:00Z, ...+09:00) it is absolute and fromTimezone is ignored. Otherwise it is a wall-clock time read in fromTimezone, defaulting to UTC",
+    ),
   fromTimezone: z
     .string()
     .max(MAX_TIMEZONE_LENGTH)
     .optional()
-    .describe("Source timezone for conversion"),
+    .describe(
+      "IANA timezone the datetime string is written in, used when the string has no offset of its own. Defaults to UTC",
+    ),
   toTimezone: z
     .string()
     .max(MAX_TIMEZONE_LENGTH)
@@ -49,7 +55,12 @@ const schema = {
 const inputSchema = z.object(schema);
 type Input = z.infer<typeof inputSchema>;
 
-function toISOInTimezone(date: Date, timezone: string): string {
+/** Wall-clock fields of `date` as seen in `timezone`. */
+function partsInTimezone(
+  date: Date,
+  timezone: string,
+  fractional = false,
+): Record<string, string> {
   const parts = new Intl.DateTimeFormat("en-US", {
     timeZone: timezone,
     year: "numeric",
@@ -58,14 +69,21 @@ function toISOInTimezone(date: Date, timezone: string): string {
     hour: "2-digit",
     minute: "2-digit",
     second: "2-digit",
-    fractionalSecondDigits: 3,
+    ...(fractional ? { fractionalSecondDigits: 3 as const } : {}),
     hour12: false,
   }).formatToParts(date);
 
-  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? "";
-  const hour = get("hour") === "24" ? "00" : get("hour");
+  const out: Record<string, string> = {};
+  for (const part of parts) out[part.type] = part.value;
+  // Some engines render midnight as hour 24.
+  if (out.hour === "24") out.hour = "00";
+  return out;
+}
 
-  return `${get("year")}-${get("month")}-${get("day")}T${hour}:${get("minute")}:${get("second")}.${get("fractionalSecond")}`;
+function toISOInTimezone(date: Date, timezone: string): string {
+  const p = partsInTimezone(date, timezone, true);
+  const get = (type: string) => p[type] ?? "";
+  return `${get("year")}-${get("month")}-${get("day")}T${get("hour")}:${get("minute")}:${get("second")}.${get("fractionalSecond")}`;
 }
 
 function getOffsetString(date: Date, timezone: string): string {
@@ -85,30 +103,84 @@ function getOffsetString(date: Date, timezone: string): string {
 }
 
 function toDateInTimezone(date: Date, timezone: string): Date {
-  const parts = new Intl.DateTimeFormat("en-US", {
-    timeZone: timezone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    fractionalSecondDigits: 3,
-    hour12: false,
-  }).formatToParts(date);
-
-  const get = (type: string) =>
-    Number.parseInt(parts.find((p) => p.type === type)?.value ?? "0", 10);
-  const hour = get("hour") === 24 ? 0 : get("hour");
-
+  const p = partsInTimezone(date, timezone, true);
+  const get = (type: string) => Number.parseInt(p[type] ?? "0", 10);
   return new Date(
     get("year"),
     get("month") - 1,
     get("day"),
-    hour,
+    get("hour"),
     get("minute"),
     get("second"),
   );
+}
+
+const WALL_CLOCK_RE =
+  /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,3}))?)?)?$/;
+
+function assertTimezone(timezone: string): void {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone });
+  } catch {
+    throw new Error(`Invalid timezone: ${timezone}`);
+  }
+}
+
+/** Offset of `timezone` from UTC at `instant`, in milliseconds. */
+function offsetMsAt(instant: Date, timezone: string): number {
+  const p = partsInTimezone(instant, timezone);
+  const get = (type: string) => Number.parseInt(p[type] ?? "0", 10);
+  const asIfUtc = Date.UTC(
+    get("year"),
+    get("month") - 1,
+    get("day"),
+    get("hour"),
+    get("minute"),
+    get("second"),
+  );
+  return asIfUtc - (instant.getTime() - instant.getMilliseconds());
+}
+
+/**
+ * Resolve a datetime string to an absolute instant.
+ *
+ * A string that carries its own UTC designator or numeric offset is already
+ * absolute, and `sourceTimezone` is ignored. A bare wall-clock string is read in
+ * `sourceTimezone`, which defaults to UTC — never the host's local zone, so the
+ * result does not depend on the machine the server runs on.
+ */
+function parseInstant(datetime: string, sourceTimezone?: string): Date {
+  const wall = datetime.trim().match(WALL_CLOCK_RE);
+  if (!wall) {
+    const absolute = new Date(datetime);
+    if (Number.isNaN(absolute.getTime()))
+      throw new Error(`Invalid datetime: ${datetime}`);
+    return absolute;
+  }
+
+  const timezone = sourceTimezone ?? "UTC";
+  assertTimezone(timezone);
+
+  const num = (v: string | undefined) =>
+    v === undefined ? 0 : Number.parseInt(v, 10);
+  const guess = Date.UTC(
+    num(wall[1]),
+    num(wall[2]) - 1,
+    num(wall[3]),
+    num(wall[4]),
+    num(wall[5]),
+    num(wall[6]),
+    num(wall[7]?.padEnd(3, "0")),
+  );
+  if (Number.isNaN(guess)) throw new Error(`Invalid datetime: ${datetime}`);
+
+  // The offset depends on the instant, and the instant depends on the offset.
+  // One refinement settles it everywhere except an ambiguous DST fold, where
+  // either reading is defensible and the first is kept.
+  const first = offsetMsAt(new Date(guess), timezone);
+  const candidate = guess - first;
+  const second = offsetMsAt(new Date(candidate), timezone);
+  return new Date(second === first ? candidate : guess - second);
 }
 
 function formatOutput(date: Date, timezone: string, format?: string): string {
@@ -178,17 +250,20 @@ export function execute(input: Input): string {
     case "convert": {
       if (!input.datetime) throw new Error("datetime is required for convert");
       const toTz = input.toTimezone ?? "UTC";
-      const date = new Date(input.datetime);
-      if (Number.isNaN(date.getTime()))
-        throw new Error(`Invalid datetime: ${input.datetime}`);
+      assertTimezone(toTz);
+      // `timezone` has no other meaning for convert, so accept it as the source
+      // when the caller did not use `fromTimezone`.
+      const date = parseInstant(
+        input.datetime,
+        input.fromTimezone ?? input.timezone,
+      );
       return formatOutput(date, toTz, input.format);
     }
     case "format": {
       if (!input.datetime) throw new Error("datetime is required for format");
       const tz = input.timezone ?? "UTC";
-      const date = new Date(input.datetime);
-      if (Number.isNaN(date.getTime()))
-        throw new Error(`Invalid datetime: ${input.datetime}`);
+      assertTimezone(tz);
+      const date = parseInstant(input.datetime, input.fromTimezone);
       return formatOutput(date, tz, input.format ?? "iso");
     }
     case "timestamp": {
@@ -198,9 +273,7 @@ export function execute(input: Input): string {
         return formatOutput(date, tz, input.format);
       }
       if (input.datetime) {
-        const date = new Date(input.datetime);
-        if (Number.isNaN(date.getTime()))
-          throw new Error(`Invalid datetime: ${input.datetime}`);
+        const date = parseInstant(input.datetime, input.fromTimezone);
         return String(Math.floor(date.getTime() / 1000));
       }
       return String(Math.floor(Date.now() / 1000));

--- a/src/tools/ip.ts
+++ b/src/tools/ip.ts
@@ -11,7 +11,13 @@ const schema = {
     .describe(
       "info: IP details, contains: check if IP in CIDR, range: CIDR range",
     ),
-  ip: z.string().max(MAX_IP_LENGTH).optional().describe("IP address"),
+  ip: z
+    .string()
+    .max(MAX_IP_LENGTH)
+    .optional()
+    .describe(
+      "IP address. For info, IPv4 CIDR notation is also accepted and the network details are included",
+    ),
   cidr: z
     .string()
     .max(MAX_IP_LENGTH)
@@ -98,9 +104,9 @@ function parseCidr(cidr: string): {
   return { network, prefix, mask };
 }
 
-function ipInfo(ip: string): string {
+function ipInfo(ip: string): Record<string, unknown> {
   if (isIPv6(ip)) {
-    return JSON.stringify({
+    return {
       ip,
       version: 6,
       type:
@@ -109,14 +115,14 @@ function ipInfo(ip: string): string {
           : ip.startsWith("fe80:")
             ? "link-local"
             : "global",
-    });
+    };
   }
 
   // ipv4ToNum validates the address and parses octets internally — avoid double-parsing
   const num = ipv4ToNum(ip);
   const firstOctet = (num >>> 24) & 0xff;
 
-  return JSON.stringify({
+  return {
     ip,
     version: 4,
     class: getIpv4Class(firstOctet),
@@ -124,14 +130,43 @@ function ipInfo(ip: string): string {
     isLoopback: firstOctet === 127,
     binary: num.toString(2).padStart(32, "0"),
     decimal: num,
-  });
+  };
+}
+
+function cidrRange(cidr: string): Record<string, unknown> {
+  const { network, prefix, mask } = parseCidr(cidr);
+  const broadcast = (network | ~mask) >>> 0;
+  const hostCount =
+    prefix >= 31 ? (prefix === 32 ? 1 : 2) : broadcast - network - 1;
+  return {
+    cidr,
+    network: numToIpv4(network),
+    broadcast: numToIpv4(broadcast),
+    firstHost: prefix >= 31 ? numToIpv4(network) : numToIpv4(network + 1),
+    lastHost: prefix >= 31 ? numToIpv4(broadcast) : numToIpv4(broadcast - 1),
+    hostCount,
+    mask: numToIpv4(mask),
+    totalAddresses: 2 ** (32 - prefix),
+  };
 }
 
 export function execute(input: Input): string {
   switch (input.action) {
     case "info": {
-      if (!input.ip) throw new Error("ip is required for info");
-      return ipInfo(input.ip);
+      const source = input.ip ?? input.cidr;
+      if (!source) throw new Error("ip or cidr is required for info");
+      const address = arrayGet(source.split("/"), 0);
+      // cidrRange is IPv4-only, so an IPv6 prefix has to say that rather than
+      // fail as though the address itself were malformed.
+      if (source.includes("/") && isIPv6(address))
+        throw new Error(
+          `IPv6 prefixes are not supported: ${source}. Pass the address alone (${address}) for info.`,
+        );
+      const info = ipInfo(address);
+      // A prefix was supplied, so report the network it describes as well.
+      return JSON.stringify(
+        source.includes("/") ? { ...info, ...cidrRange(source) } : info,
+      );
     }
     case "contains": {
       if (!input.cidr) throw new Error("cidr is required for contains");
@@ -146,20 +181,7 @@ export function execute(input: Input): string {
     }
     case "range": {
       if (!input.cidr) throw new Error("cidr is required for range");
-      const { network, prefix, mask } = parseCidr(input.cidr);
-      const broadcast = (network | ~mask) >>> 0;
-      const hostCount =
-        prefix >= 31 ? (prefix === 32 ? 1 : 2) : broadcast - network - 1;
-      return JSON.stringify({
-        cidr: input.cidr,
-        network: numToIpv4(network),
-        broadcast: numToIpv4(broadcast),
-        firstHost: prefix >= 31 ? numToIpv4(network) : numToIpv4(network + 1),
-        lastHost:
-          prefix >= 31 ? numToIpv4(broadcast) : numToIpv4(broadcast - 1),
-        hostCount,
-        mask: numToIpv4(mask),
-      });
+      return JSON.stringify(cidrRange(input.cidr));
     }
   }
 }

--- a/src/tools/semver.ts
+++ b/src/tools/semver.ts
@@ -85,18 +85,59 @@ function compare(a: SemVer, b: SemVer): number {
   return comparePre(a.prerelease, b.prerelease);
 }
 
+/** Every version-like token in one comparator set, operators stripped. */
+function comparatorVersions(set: string): SemVer[] {
+  const hyphen = set.match(/^(.+?)\s+-\s+(.+)$/);
+  const tokens =
+    hyphen?.[1] && hyphen[2] ? [hyphen[1], hyphen[2]] : set.split(/\s+/);
+  const out: SemVer[] = [];
+  for (const token of tokens) {
+    const parsed = parse(token.replace(/^(>=|<=|>|<|=|\^|~)\s*/, ""));
+    if (parsed) out.push(parsed);
+  }
+  return out;
+}
+
+/**
+ * node-semver's prerelease rule: a version carrying a prerelease tag satisfies a
+ * comparator set only if some comparator in that set pins the same
+ * [major, minor, patch] and carries a prerelease tag of its own. Prereleases
+ * change under a stable version number, so a range that never mentions one is
+ * read as not opting into any.
+ */
+function setAdmitsPrerelease(version: SemVer, set: string): boolean {
+  return comparatorVersions(set).some(
+    (c) =>
+      c.prerelease.length > 0 &&
+      c.major === version.major &&
+      c.minor === version.minor &&
+      c.patch === version.patch,
+  );
+}
+
 function satisfies(version: SemVer, range: string): boolean {
   const trimmed = range.trim();
 
-  // Handle OR (||)
+  // Handle OR (||) — each alternative is its own comparator set.
   if (trimmed.includes("||")) {
     return trimmed.split("||").some((r) => satisfies(version, r.trim()));
   }
 
+  // The rule applies once per set, so it is checked here rather than inside
+  // satisfiesSet, which recurses into the individual comparators.
+  if (version.prerelease.length > 0 && !setAdmitsPrerelease(version, trimmed)) {
+    return false;
+  }
+  return satisfiesSet(version, trimmed);
+}
+
+function satisfiesSet(version: SemVer, set: string): boolean {
+  const trimmed = set.trim();
+
   // Handle AND (space-separated ranges like ">=1.0.0 <2.0.0")
   const parts = trimmed.split(/\s+/);
   if (parts.length > 1 && parts.every((p) => /^[><=~^]/.test(p))) {
-    return parts.every((p) => satisfies(version, p));
+    return parts.every((p) => satisfiesSet(version, p));
   }
 
   // Handle hyphen range (1.0.0 - 2.0.0)

--- a/src/tools/url_parse.ts
+++ b/src/tools/url_parse.ts
@@ -25,9 +25,15 @@ export function execute(input: Input): string {
     throw new Error(`Invalid URL: ${input.url}`);
   }
 
-  const searchParams: Record<string, string> = {};
+  // A query string may repeat a key, and an object can hold one value per key.
+  // Collapsing to the last value silently drops the others, so a repeated key
+  // becomes an array of every value in the order they appear.
+  const searchParams: Record<string, string | string[]> = {};
   for (const [key, value] of parsed.searchParams) {
-    searchParams[key] = value;
+    const seen = searchParams[key];
+    if (seen === undefined) searchParams[key] = value;
+    else if (Array.isArray(seen)) seen.push(value);
+    else searchParams[key] = [seen, value];
   }
 
   return JSON.stringify(

--- a/tests/tools/datetime.test.ts
+++ b/tests/tools/datetime.test.ts
@@ -182,3 +182,124 @@ describe("datetime - timestamp", () => {
     expect(Number(back)).toBe(original);
   });
 });
+
+describe("datetime - convert reads the source timezone", () => {
+  test("interprets a bare wall clock in fromTimezone", () => {
+    // 2026-11-03 falls after US DST ends, so New York is EST (UTC-5).
+    const result = execute({
+      action: "convert",
+      datetime: "2026-11-03 14:30",
+      fromTimezone: "America/New_York",
+      toTimezone: "UTC",
+    });
+    expect(result).toContain("2026-11-03T19:30:00");
+    expect(result).toContain("+00:00");
+  });
+
+  test("uses the offset in effect on that date, not a fixed one", () => {
+    // The same wall clock in June, when New York is EDT (UTC-4).
+    const result = execute({
+      action: "convert",
+      datetime: "2026-06-15 14:30",
+      fromTimezone: "America/New_York",
+      toTimezone: "UTC",
+    });
+    expect(result).toContain("2026-06-15T18:30:00");
+  });
+
+  test("UTC to UTC leaves the wall clock untouched", () => {
+    const result = execute({
+      action: "convert",
+      datetime: "2026-11-03 14:30",
+      fromTimezone: "UTC",
+      toTimezone: "UTC",
+    });
+    expect(result).toContain("2026-11-03T14:30:00");
+  });
+
+  test("defaults the source to UTC, so output does not depend on the host", () => {
+    const implicit = execute({
+      action: "convert",
+      datetime: "2026-11-03 14:30",
+      toTimezone: "UTC",
+    });
+    const explicit = execute({
+      action: "convert",
+      datetime: "2026-11-03 14:30",
+      fromTimezone: "UTC",
+      toTimezone: "UTC",
+    });
+    expect(implicit).toBe(explicit);
+    expect(implicit).toContain("2026-11-03T14:30:00");
+  });
+
+  test("accepts timezone as the source when fromTimezone is absent", () => {
+    const result = execute({
+      action: "convert",
+      datetime: "2026-11-03 14:30",
+      timezone: "America/New_York",
+      toTimezone: "UTC",
+    });
+    expect(result).toContain("2026-11-03T19:30:00");
+  });
+
+  test("an offset in the string wins over fromTimezone", () => {
+    const result = execute({
+      action: "convert",
+      datetime: "2026-11-03T19:30:00Z",
+      fromTimezone: "America/New_York",
+      toTimezone: "Asia/Tokyo",
+    });
+    expect(result).toContain("2026-11-04T04:30:00");
+  });
+
+  test("throws on an unknown source timezone", () => {
+    expect(() =>
+      execute({
+        action: "convert",
+        datetime: "2026-11-03 14:30",
+        fromTimezone: "Mars/Olympus",
+        toTimezone: "UTC",
+      }),
+    ).toThrow("Invalid timezone");
+  });
+
+  test("throws on an unknown target timezone", () => {
+    expect(() =>
+      execute({
+        action: "convert",
+        datetime: "2026-11-03T14:30:00Z",
+        toTimezone: "Mars/Olympus",
+      }),
+    ).toThrow("Invalid timezone");
+  });
+});
+
+describe("datetime - fromTimezone on format and timestamp", () => {
+  test("format reads the source timezone", () => {
+    const result = execute({
+      action: "format",
+      datetime: "2026-03-01 12:00",
+      fromTimezone: "Europe/Berlin",
+      timezone: "UTC",
+      format: "iso",
+    });
+    expect(result).toContain("2026-03-01T11:00:00");
+  });
+
+  test("timestamp reads the source timezone", () => {
+    expect(
+      execute({
+        action: "timestamp",
+        datetime: "2026-01-01 00:00",
+        fromTimezone: "Asia/Tokyo",
+      }),
+    ).toBe("1767193200");
+  });
+
+  test("timestamp defaults the source to UTC", () => {
+    expect(execute({ action: "timestamp", datetime: "2026-01-01 00:00" })).toBe(
+      "1767225600",
+    );
+  });
+});

--- a/tests/tools/ip.test.ts
+++ b/tests/tools/ip.test.ts
@@ -74,3 +74,64 @@ describe("ip", () => {
     expect(() => execute({ action: "info", ip: ":::1" })).toThrow();
   });
 });
+
+describe("ip - info accepts a prefix", () => {
+  test("takes CIDR notation in ip and reports the network it describes", () => {
+    const result = JSON.parse(execute({ action: "info", ip: "10.0.0.0/29" }));
+    expect(result.ip).toBe("10.0.0.0");
+    expect(result.version).toBe(4);
+    expect(result.network).toBe("10.0.0.0");
+    expect(result.broadcast).toBe("10.0.0.7");
+    expect(result.hostCount).toBe(6);
+    expect(result.totalAddresses).toBe(8);
+  });
+
+  test("takes the prefix through cidr instead", () => {
+    const result = JSON.parse(
+      execute({ action: "info", cidr: "192.168.5.130/26" }),
+    );
+    expect(result.ip).toBe("192.168.5.130");
+    expect(result.network).toBe("192.168.5.128");
+    expect(result.broadcast).toBe("192.168.5.191");
+  });
+
+  test("a bare address carries no network fields", () => {
+    const result = JSON.parse(execute({ action: "info", ip: "192.168.5.130" }));
+    expect(result.isPrivate).toBe(true);
+    expect(result.network).toBeUndefined();
+  });
+
+  test("throws when neither ip nor cidr is given", () => {
+    expect(() => execute({ action: "info" })).toThrow("ip or cidr is required");
+  });
+});
+
+describe("ip - range reports the address count", () => {
+  test("counts every address in the block, not just usable hosts", () => {
+    const result = JSON.parse(
+      execute({ action: "range", cidr: "10.1.0.0/20" }),
+    );
+    expect(result.totalAddresses).toBe(4096);
+    expect(result.hostCount).toBe(4094);
+    expect(result.broadcast).toBe("10.1.15.255");
+  });
+});
+
+describe("ip - info rejects an IPv6 prefix clearly", () => {
+  test("names the address to pass instead", () => {
+    // cidrRange is IPv4-only, so the old path failed as though the address
+    // itself were malformed.
+    expect(() => execute({ action: "info", ip: "2001:db8::/32" })).toThrow(
+      "IPv6 prefixes are not supported",
+    );
+    expect(() => execute({ action: "info", cidr: "2001:db8::/32" })).toThrow(
+      "2001:db8::",
+    );
+  });
+
+  test("a bare IPv6 address still works", () => {
+    const result = JSON.parse(execute({ action: "info", ip: "2001:db8::1" }));
+    expect(result.version).toBe(6);
+    expect(result.type).toBe("global");
+  });
+});

--- a/tests/tools/semver.test.ts
+++ b/tests/tools/semver.test.ts
@@ -309,13 +309,63 @@ describe("semver", () => {
   });
 
   test("handles prerelease versions in hyphen range", () => {
-    const result = JSON.parse(
+    // A hyphen range expands to >=1.0.0-alpha <=2.0.0-rc. Neither comparator
+    // pins the tuple 1.5.0, so a 1.5.0 prerelease is not admitted, while the
+    // stable 1.5.0 is. Checked against node-semver 7.8.5.
+    const prerelease = JSON.parse(
       execute({
         action: "satisfies",
         version: "1.5.0-beta",
         range: "1.0.0-alpha - 2.0.0-rc",
       }),
     );
-    expect(result.satisfies).toBe(true);
+    expect(prerelease.satisfies).toBe(false);
+
+    const stable = JSON.parse(
+      execute({
+        action: "satisfies",
+        version: "1.5.0",
+        range: "1.0.0-alpha - 2.0.0-rc",
+      }),
+    );
+    expect(stable.satisfies).toBe(true);
+  });
+});
+
+describe("semver - prerelease versions against ranges", () => {
+  const satisfies = (version: string, range: string) =>
+    JSON.parse(execute({ action: "satisfies", version, range })).satisfies;
+
+  test("a prerelease is excluded from a range that never mentions one", () => {
+    // <2.0.0 pins the tuple 2.0.0 but carries no prerelease tag, so 2.0.0-rc.1
+    // must not satisfy it.
+    expect(satisfies("2.0.0-rc.1", ">=1.4.0 <2.0.0")).toBe(false);
+    expect(satisfies("1.4.0-beta.2", ">=1.4.0 <2.0.0")).toBe(false);
+    expect(satisfies("1.0.0-rc.1", "^1.0.0")).toBe(false);
+    expect(satisfies("1.2.3-rc.1", "1.x")).toBe(false);
+  });
+
+  test("stable versions in the same range are unaffected", () => {
+    expect(satisfies("1.4.0", ">=1.4.0 <2.0.0")).toBe(true);
+    expect(satisfies("1.9.0", ">=1.4.0 <2.0.0")).toBe(true);
+    expect(satisfies("1.10.2", ">=1.4.0 <2.0.0")).toBe(true);
+    expect(satisfies("2.0.0", ">=1.4.0 <2.0.0")).toBe(false);
+  });
+
+  test("a comparator with a prerelease opts that tuple in", () => {
+    expect(satisfies("1.2.3-alpha.7", ">1.2.3-alpha.3")).toBe(true);
+    expect(satisfies("3.4.5-alpha.9", ">1.2.3-alpha.3")).toBe(false);
+    expect(satisfies("3.4.5", ">1.2.3-alpha.3")).toBe(true);
+    expect(satisfies("1.0.0-rc.2", "^1.0.0-rc.1")).toBe(true);
+  });
+
+  test("the rule applies to the comparator set, not to each comparator", () => {
+    // >=1.4.0-rc.1 opts the 1.4.0 tuple in; <2.0.0 must not veto it.
+    expect(satisfies("1.4.0-rc.2", ">=1.4.0-rc.1 <2.0.0")).toBe(true);
+  });
+
+  test("each alternative of an OR range is its own set", () => {
+    expect(satisfies("1.2.3-rc.1", ">=1.0.0 || 1.2.3-rc.1")).toBe(true);
+    expect(satisfies("1.2.3-rc.1", ">=1.0.0 || >=2.0.0")).toBe(false);
   });
 });

--- a/tests/tools/url_parse.test.ts
+++ b/tests/tools/url_parse.test.ts
@@ -49,3 +49,25 @@ describe("url_parse", () => {
     expect(result.href).toBe("https://example.com/path");
   });
 });
+
+describe("url_parse - repeated query keys", () => {
+  test("keeps every value of a repeated key, in the order they appear", () => {
+    const result = JSON.parse(
+      execute({ url: "https://example.com/p?q=first&page=3&q=second" }),
+    );
+    expect(result.searchParams.q).toEqual(["first", "second"]);
+    expect(result.searchParams.page).toBe("3");
+  });
+
+  test("a key that appears once stays a string", () => {
+    const result = JSON.parse(execute({ url: "https://example.com/p?q=only" }));
+    expect(result.searchParams.q).toBe("only");
+  });
+
+  test("decodes percent-encoded values", () => {
+    const result = JSON.parse(
+      execute({ url: "https://example.com/p?q=%E6%9D%B1%E4%BA%AC%20duck" }),
+    );
+    expect(result.searchParams.q).toBe("東京 duck");
+  });
+});


### PR DESCRIPTION
Four tools returned wrong answers. Each was found by cross-checking the tool against an independent reference implementation, and each expected value in the new tests comes from that reference rather than from calc-mcp itself.

## `datetime` ignored `fromTimezone` entirely

It was declared in the schema and documented as the source timezone, but nothing read it. `convert` built its instant with `new Date(input.datetime)`, which reads an offset-less string as host-local time, so the source zone was always whatever machine the server happened to run on:

| request | before | correct |
|---|---|---|
| NY 14:30 → UTC, host `Asia/Tokyo` | `2026-11-03T05:30:00.000+00:00` | `19:30Z` |
| UTC → UTC (an identity) | `2026-11-03T05:30:00.000+00:00` | `14:30Z` |
| NY 14:30 → UTC, host `UTC` | `2026-11-03T14:30:00.000+00:00` | `19:30Z` |

The third row is the one that matters: the same request answered differently depending on the host, and the second shows an identity conversion moving the clock nine hours.

`parseInstant` now resolves a datetime string once, for `convert`, `format` and `timestamp` alike. A string carrying a UTC designator or a numeric offset is already absolute and `fromTimezone` is ignored. A bare wall-clock string is read in `fromTimezone`, defaulting to UTC rather than the host zone. The offset is resolved at the instant in question, so November gets EST and June gets EDT.

`docs/examples.md` already documented the correct answer for a New-York-to-Tokyo conversion that the implementation did not produce; it now matches. A neighbouring example claimed a date-only input formats as 12:00 in Tokyo, which no source timezone produces.

Every existing `convert` test passed an explicit offset, which is why the gap survived.

## `ip` action `info` rejected CIDR notation

`{action:"info", cidr:"10.0.0.0/29"}` failed with `ip is required for info`, and the same value in `ip` failed with `Invalid IPv4 address`. The network figures live under `range`, and neither error said so, so a caller reaching for `info` on a block hit a dead end. `cidr` was also accepted for `info` and then silently ignored.

`info` now takes the prefix from either field and reports the network it describes. `range` gains `totalAddresses`, which counts every address in the block, next to `hostCount`, which excludes the network and broadcast addresses.

`cidrRange` is IPv4-only, so an IPv6 prefix now fails with a message naming the address to pass instead, rather than reporting the address as malformed.

## `url_parse` dropped repeated query keys

`?q=first&page=3&q=second` reported `q: "second"` with no sign a value had been lost. A key that appears once still maps to a string; a key that repeats maps to an array of every value, in order.

## `semver` admitted pre-releases into ranges that never mention one

`satisfies` reported that `2.0.0-rc.1` satisfies `>=1.4.0 <2.0.0`. node-semver's rule is that a version carrying a pre-release tag satisfies a comparator set only if some comparator in that set pins the same `[major, minor, patch]` and carries a pre-release tag of its own; `<2.0.0` pins the tuple 2.0.0 but names no pre-release, so the answer is false.

The check belongs to the comparator set rather than to each comparator, so `satisfies` applies it once per set and delegates to `satisfiesSet`, which recurses into the individual comparators. Gating per comparator would have rejected `>=1.4.0-rc.1 <2.0.0` for `1.4.0-rc.2`, where the first comparator opts the 1.4.0 tuple in and the second must not veto it.

All fifteen cases in the new tests were checked against node-semver 7.8.5, which also disagreed with the existing hyphen-range test: that test asserted `1.5.0-beta` satisfies `1.0.0-alpha - 2.0.0-rc`, codifying the old behaviour. Neither comparator pins the tuple 1.5.0, so it now asserts false for the pre-release and true for the stable `1.5.0`.

## Project rules

`CLAUDE.md` had three claims that no longer matched the repo. It said indentation is tabs where `biome.json` sets 2 spaces (stated twice), it said Biome warnings are treated as errors in CI where `biome check .` exits 0 on them, and its `ci.yml` row named a push trigger that does not exist while omitting both the develop branch and the audit job.

`CHANGELOG.md` is untouched, per the changelog policy.

## Verification

`bun run ci` passes: lint, build, and 536 tests, 26 of them new. The datetime tests were also run under `TZ=Asia/Tokyo`, `TZ=UTC` and `TZ=America/Los_Angeles` to confirm the output no longer depends on the host.
